### PR TITLE
fixed panel-checkbox

### DIFF
--- a/documentation/components/panel.html
+++ b/documentation/components/panel.html
@@ -99,7 +99,7 @@ doc-subtab: panel
     </span>
     grumpy-cat
   </a>
-  <label class="panel-checkbox">
+  <label class="panel-block">
     <input type="checkbox">
     Remember me
   </label>


### PR DESCRIPTION
possible fix for #51

changed the panel-checkbox to the every else used panel-block, as it was used in the [source (L36)](https://github.com/jgthms/bulma-website/blob/master/documentation/components/panel.html#L36).